### PR TITLE
Port to GNOME Shell 45 and 46, clean-up code

### DIFF
--- a/hideLockScreenItem@user.extension.mail/extension.js
+++ b/hideLockScreenItem@user.extension.mail/extension.js
@@ -1,32 +1,41 @@
-const Main = imports.ui.main;
-const GLib = imports.gi.GLib;
+import GLib from 'gi://GLib';
 
-let matchingActions = imports.misc.systemActions.getDefault().getMatchingActions;
+import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
+import * as systemActions from 'resource:///org/gnome/shell/misc/systemActions.js';
 
-function _removeMatchingActions(terms) {
-    
-    terms = terms.map(term => GLib.str_tokenize_and_fold(term, null)[0]).flat(2);
-    
-    if (terms.length === 0)
-    	return [];
-
-    let results = [];
-
-    for (let [key, { available, keywords }] of this._actions) {
-    	if (available && terms.every(t => keywords.some(k => k.startsWith(t)))) {
-    			if (key != 'lock-screen')
-    				results.push(key);
-    			}
+export default class HideLockScreenItemExtension extends Extension {
+    init() {
+        // store pristine function
+        this.matchingActions = systemActions.getDefault().getMatchingActions;
     }
-    return results;
-   
-}
 
-function init() {
-}
+    enable() {
+        // replace with our modified implementation
+        systemActions.getDefault().getMatchingActions = this._removeMatchingActions;
+    }
 
-function enable() { imports.misc.systemActions.getDefault().getMatchingActions = _removeMatchingActions;
-}
+    disable() {
+        // restore pristine function
+        systemActions.getDefault().getMatchingActions = matchingActions;
+    }
+
+    _removeMatchingActions(terms) {
+        // terms is a list of strings
+        terms = terms.map(
+            term => GLib.str_tokenize_and_fold(term, null)[0]).flat(2);
+
+        // tokenizing may return an empty array
+        if (terms.length === 0)
+            return [];
     
-function disable() { imports.misc.systemActions.getDefault().getMatchingActions = matchingActions;
+        let results = [];
+
+        for (let [key, {available, keywords}] of this._actions) {
+            if (available && terms.every(t => keywords.some(k => k.startsWith(t)))) {
+                if (key != 'lock-screen')
+                    results.push(key);
+            }
+        }
+        return results;
+    }
 }

--- a/hideLockScreenItem@user.extension.mail/metadata.json
+++ b/hideLockScreenItem@user.extension.mail/metadata.json
@@ -2,7 +2,8 @@
   "description": "Hide Lock Screen Item from Show Apps Menu",
   "name": "Hide Lock Screen Item from Show Apps Menu",
   "shell-version": [
-    "42"
+    "45",
+    "46"
   ],
   "url": "",
   "uuid": "hideLockScreenItem@user.extension.mail",


### PR DESCRIPTION
Thanks for this extension! This MR adds support for the latest GNOME Shell Versions 45 and 46.

Migration:
- Use ECMAScript modules import declarations
- Refactor to export a default class
- Migration guide: https://gjs.guide/extensions/upgrading/gnome-shell-45.html#esm

Clean-up:
- Re-format code to match original function in gnome-shell


License: GPL-3.0